### PR TITLE
Ensure items with the same created value are claimed in order of actual creation (using item_id).

### DIFF
--- a/src/Queue/SystemSetQueue.php
+++ b/src/Queue/SystemSetQueue.php
@@ -63,7 +63,7 @@ class SystemSetQueue implements \DrupalQueueInterface {
     // until an item is successfully claimed or we are reasonably sure there
     // are no unclaimed items left.
     while (TRUE) {
-      $item = db_query_range('SELECT data, item_id FROM {' . static::TABLE_NAME . '} q WHERE expire = 0 AND name = :name ORDER BY created ASC', 0, 1, array(':name' => $this->name))->fetchObject();
+      $item = db_query_range('SELECT data, item_id FROM {' . static::TABLE_NAME . '} q WHERE expire = 0 AND name = :name ORDER BY created, item_id ASC', 0, 1, array(':name' => $this->name))->fetchObject();
       if ($item) {
         // Try to update the item. Only one thread can succeed in UPDATEing the
         // same row. We cannot rely on REQUEST_TIME because items might be


### PR DESCRIPTION
This is the same fix committed to Drupal 7's SystemQueue class: https://www.drupal.org/node/2356983
